### PR TITLE
Fix build with modern Cargo

### DIFF
--- a/open/bosminer/Cargo.lock
+++ b/open/bosminer/Cargo.lock
@@ -102,7 +102,6 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -803,7 +802,7 @@ name = "libusb"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bit-set 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.2.0",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libusb-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1771,7 +1770,6 @@ dependencies = [
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum bare-metal 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bit-set 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e1e6fb1c9e3d6fcdec57216a74eaa03e41f52a22f13a16438251d8e88b89da"
 "checksum bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
 "checksum bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"

--- a/open/bosminer/Cargo.toml
+++ b/open/bosminer/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "bosminer-erupter",
     "bosminer-macros",
 ]
+
+[patch.crates-io]
+bit-set = { path = "../third-party/bit-set-0.2.0" }

--- a/open/bosminer/bosminer-erupter/Cargo.toml
+++ b/open/bosminer/bosminer-erupter/Cargo.toml
@@ -18,3 +18,6 @@ packed_struct="0.3"
 packed_struct_codegen = "0.3"
 libusb = { version = "0.3.0" }
 config = "0.9.3"
+
+[patch.crates-io]
+bit-set = { path = "../../third-party/bit-set-0.2.0" }

--- a/open/third-party/bit-set-0.2.0/Cargo.toml
+++ b/open/third-party/bit-set-0.2.0/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "bit-set"
+version = "0.2.0"
+edition = "2018"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+bit-vec = "0.6"

--- a/open/third-party/bit-set-0.2.0/src/lib.rs
+++ b/open/third-party/bit-set-0.2.0/src/lib.rs
@@ -1,0 +1,83 @@
+use bit_vec::BitVec;
+
+#[derive(Clone, Debug, Default)]
+pub struct BitSet {
+    bits: BitVec,
+}
+
+impl BitSet {
+    pub fn new() -> Self {
+        Self { bits: BitVec::new() }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { bits: BitVec::from_elem(capacity, false) }
+    }
+
+    fn ensure(&mut self, index: usize) {
+        if index >= self.bits.len() {
+            self.bits.grow(index + 1 - self.bits.len(), false);
+        }
+    }
+
+    pub fn insert(&mut self, index: usize) -> bool {
+        self.ensure(index);
+        let old = self.bits.get(index).unwrap_or(false);
+        self.bits.set(index, true);
+        !old
+    }
+
+    pub fn remove(&mut self, index: usize) -> bool {
+        if index < self.bits.len() {
+            let old = self.bits.get(index).unwrap_or(false);
+            self.bits.set(index, false);
+            old
+        } else {
+            false
+        }
+    }
+
+    pub fn contains(&self, index: usize) -> bool {
+        self.bits.get(index).unwrap_or(false)
+    }
+
+    pub fn clear(&mut self) {
+        self.bits.clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        !self.bits.any()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
+        self.bits.iter().enumerate().filter_map(|(i, b)| if b { Some(i) } else { None })
+    }
+
+    pub fn union_with(&mut self, other: &Self) {
+        if other.bits.len() > self.bits.len() {
+            self.bits.grow(other.bits.len() - self.bits.len(), false);
+        }
+        for i in other.iter() {
+            self.bits.set(i, true);
+        }
+    }
+}
+
+impl FromIterator<usize> for BitSet {
+    fn from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Self {
+        let mut set = BitSet::new();
+        for i in iter {
+            set.insert(i);
+        }
+        set
+    }
+}
+
+impl IntoIterator for BitSet {
+    type Item = usize;
+    type IntoIter = std::vec::IntoIter<usize>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter().collect::<Vec<_>>().into_iter()
+    }
+}


### PR DESCRIPTION
## Summary
- patch bit-set 0.2.0 so crates using libusb build on recent Rust
- use `[patch.crates-io]` in `bosminer` workspace and erupter crate
- vendor a small replacement for the old `bit-set` crate

## Testing
- `cargo build --locked --offline` *(fails: no matching package named `downcast-rs` found)*